### PR TITLE
Edit with removal, endless FeatureTypes, dynamic selectboxes, hover effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,9 +35,10 @@
 <section class="add-monster">
 <h2 class="add-header">Add monster</h2>
 <form class="add-monster-form">
-    <label class="input-label">Monster name:</label> <br>
-    <input type="text" id="monster-name" name="monster-name"  placeholder="create a name...">
-    
+    <label class="input-label">Monster name:</label><input type="text" id="monster-name" name="monster-name"  placeholder="create a name...">
+
+<!-- Tidigare pre-JS kod (numera replikerad i JSn för mer dynamik )-->
+<!--
 <label class="input-label">Color:</label> <br>
     <select name="color" id="color-select">
       <option value="none" selected disabled hidden>Pick a color...</option>
@@ -55,11 +56,27 @@
       <option value="Mid">Mid</option>
       <option value="Large">Large</option>
       <option value="XXL">XXL</option>
-    </select >
-
-    <input id="sub-btn" type="submit" value="Add monster">
+    </select>
+   
+    <input id="sub-btn" class="sub-btn" type="submit" value="Add monster">
+    <input id="edit-btn" class="sub-btn" type="submit" value="Edit monsters">
+    -->
   </form>
 </section>
+
+<!-- edit monster section -->
+<section class="edit-monsters">
+    <h2 class="add-header">Edit monsters</h2>
+    <form class="add-monster-form">
+        <label class="input-label">Monster features (click to remove):</label>
+        <div class="monster-features">
+
+        </div>
+        <input id="sub-btn" class="sub-btn" type="submit" value="Save changes">
+        <input id="edit-btn2" class="sub-btn" type="submit" value="Add monster">
+        
+      </form>
+    </section>
 
 <!-- Section for monster li -->
 <section class="monster-type">  

--- a/script.js
+++ b/script.js
@@ -6,16 +6,25 @@ function displayMinfo() {
     audioMonster.play();
 }
 
+let editbtn2 = document.querySelector('#edit-btn2');
 
-
-
-let btn = document.querySelector('#sub-btn');
 let headertext =  document.querySelector("#header-text");
+
 let main =  document.querySelector(".monster-showcase");
+let addMonster = document.querySelector(".add-monster");
+let editMonsters = document.querySelector(".edit-monsters");
 let mcolors = document.querySelector("#monster-color-list");
 let mtypes = document.querySelector("#monster-type-list");
 
-// MonsterObjekt med en array som innehåller monster , samt en addMonster metod.
+let monsterFeaturesDiv = document.querySelector(".monster-features");
+
+
+// Använder en querySelectorAll för att hämta samtliga items med mfeatures-checkboxes class på sig
+let mfeaturesCheckboxes = document.querySelectorAll(".mfeatures-checkboxes");
+
+let addMonsterForm = document.querySelector(".add-monster-form"); // Add Monster Form sektionen
+
+// MonsterObjekt med en array som innehåller monster , samt en addMonster metod
 const monsterObject = {
     monster: [
         {
@@ -59,11 +68,13 @@ const monsterObject = {
     filteredMonsters: [{}],
 
  /* --------Funktion för att lägga till monster samt kolla så inte användaren lägger till dubletter------- */
-    addMonster: function() {
+    addMonster: function(newName, select) {
 
+        /*
         let newName = document.querySelector("#monster-name").value;
         let newColor = document.querySelector("#color-select").value;
         let newType = document.querySelector("#monster-type").value;
+        */
 
         const duplicate = this.monster.map(e => e.name).indexOf(newName);
         
@@ -72,25 +83,241 @@ const monsterObject = {
         // Returns: A new array with each element being the result of the callback function.
         // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
         if(duplicate!==-1) { alert('Monstret finns redan! Välj ett annat namn!');
-        }else {
+        } else {
 
-       this.monster.push({
-            name: newName,
-            color: newColor,
-            type: newType,   });
+            let feature;
+            let newMonster; 
+            newMonster = { name: newName } // Lägg in det nya monstrets namn
 
+            // Loopa igenom monsterFeatureType för att hämta alla selectade FeatureType värden
+            for(let i=0; i<monsterObject.monsterFeatureType.length; i++) {     
+                feature = this.monsterFeatureType[i].toLowerCase(); // FeatureType konvertering från VERSALER till gemener
+                newMonster[feature] = select[i].value; // Lägg in de VALUES som selectats    
+            }
+           
+       // Pusha det nya monsterObjektet till monsterObject.monster Arrayen.    
+       this.monster.push(newMonster); 
+       
+        // Nollställ monster-name inför nästa inlägg
         document.querySelector("#monster-name").value = "";
+
+        /* // Ej nollställda i dagsläget
         document.querySelector("#color-select").value = "";
         document.querySelector("#monster-type").value = "";
+            */
 
         showMonsterColors();
         showMonsterTypes();
-        console.log(this.monster);
+      
+        }
+
+    }, 
+    // Method to remove monster feature
+    removeFeature: function(id) {
+    
+       this.monsterFeatures[id] = []; // Reset feature to zero/undefined
+   
+    }, 
+
+    monsterFeatures: [],
+    monsterFeatureType: ['Color','Type'],
+
+}
+
+// Diverse DEFAULT-VÄRDEN till monsterFeatures och MonsterFeatureTypes.
+// Color features type of feature as id (linked to item in monsterFeatureType Array)
+monsterObject.monsterFeatures[0] = [];
+monsterObject.monsterFeatures[1] = [];
+monsterObject.monsterFeatures[2] = [];
+monsterObject.monsterFeatures[3] = [];
+monsterObject.monsterFeatures[4] = [];
+monsterObject.monsterFeatures[5] = [];
+monsterObject.monsterFeatures[6] = [];
+monsterObject.monsterFeatures[7] = [];
+
+monsterObject.monsterFeatures[0][0] = 0;
+monsterObject.monsterFeatures[1][0] = 0;
+monsterObject.monsterFeatures[2][0] = 0;
+monsterObject.monsterFeatures[3][0] = 0;
+monsterObject.monsterFeatures[4][0] = 0;
+monsterObject.monsterFeatures[0][1] = 'Yellow';
+monsterObject.monsterFeatures[1][1] = 'Pink';
+monsterObject.monsterFeatures[2][1] = 'Brown';
+monsterObject.monsterFeatures[3][1] = 'Black';
+monsterObject.monsterFeatures[4][1] = 'Green';
+
+monsterObject.monsterFeatures[5][0] = 1;
+monsterObject.monsterFeatures[6][0] = 1;
+monsterObject.monsterFeatures[7][0] = 1;
+monsterObject.monsterFeatures[5][1] = 'Small';
+monsterObject.monsterFeatures[6][1] = 'Mid';
+monsterObject.monsterFeatures[7][1] = 'Large';
+
+monsterObject.monsterFeatures[0][2] = '#ffff00';
+monsterObject.monsterFeatures[1][2] = '#ff00ff';
+monsterObject.monsterFeatures[2][2] = '#800000';
+monsterObject.monsterFeatures[3][2] = '#000000';
+monsterObject.monsterFeatures[4][2] = '#00ff00';
+
+monsterObject.monsterFeatures[5][2] = '#ffffff';
+monsterObject.monsterFeatures[6][2] = '#ffffff';
+monsterObject.monsterFeatures[7][2] = '#ffffff';
+
+
+
+function LoadSelectBoxes() {
+
+    let select = []; // Deklarera en select array
+    let option = []; // Deklarera en option array
+    let label = []; // Deklarera en label array
+    let monsterFeatureType;
+    let monsterFeature;
+    let typid;
+
+    // Ta fram SELECT-boxar baserat på vilka olika Feature Typer som finns i objektets array monsterFeatureType.
+    // Default är Color och Type. Ta även fram tillhörande Labels.
+    for(let i=0; i<monsterObject.monsterFeatureType.length; i++) {
+
+        // T ex Color, eller Type
+        monsterFeatureType = monsterObject.monsterFeatureType[i]; // Sätt typ av Monster Feature
+
+        label[i] = document.createElement("label");
+        label[i].setAttribute("class", "input-label");   
+        label[i].innerText = monsterFeatureType + ":"; // T ex Color: eller Type:     
+
+        select[i] = document.createElement("select");
+        select[i].setAttribute("id", `${monsterFeatureType}-select`);
+
+        option[i] = []; // Deklarera att option med indexet i också är en array
+
+        // Ta fram <option> element baserat på vilka olika Features som finns i objektets array monsterFeatures
+        for (let j=0;j<monsterObject.monsterFeatures.length; j++) {
+
+            // Populera respektive SELECT med rätt FeatureTyp med hjälp av ett IF statement
+            // i [0] i monsterFeatures ligger nyckeln till associerad FeatureType. T ex Green till Color. Small till Type, osv.
+            if (monsterObject.monsterFeatures[j][0]==i) {
+                monsterFeature = monsterObject.monsterFeatures[j][1]; // [1] = Namn på featuren
+                typid = monsterObject.monsterFeatures[i][0]; // [0] = featurens TypID i monsterFeatureType arrayen. T ex 0 för Color
+                option[i][j] = document.createElement("option");
+                option[i][j].setAttribute("value", monsterFeature);
+                option[i][j].innerText = monsterFeature;
+                select[i].appendChild(option[i][j]); // Lägg den genererade optionen i select-elementet
+            }     
+            //console.log(option[i][j]);
 
         }
 
+
+
+
+        
+        addMonsterForm.appendChild(label[i]); // xxx
+        addMonsterForm.appendChild(select[i]); // xxx
+
     }
+
+    let inputAddButton = document.createElement("input");
+    inputAddButton.setAttribute("id", "sub-btn");
+    inputAddButton.setAttribute("class", "sub-btn");
+    inputAddButton.setAttribute("type", "submit");
+    inputAddButton.setAttribute("value", "Add monster"); 
+
+    let inputEditButton = document.createElement("input");
+    inputEditButton.setAttribute("id", "edit-btn");
+    inputEditButton.setAttribute("class", "sub-btn");
+    inputEditButton.setAttribute("type", "submit");
+    inputEditButton.setAttribute("value", "Edit monster"); 
+
+    inputAddButton.addEventListener("click", function(e){
+
+        
+        let newName = document.querySelector("#monster-name").value;
+
+        /*
+        let newColor = document.querySelector("#color-select").value;
+        let newType = document.querySelector("#monster-type").value;
+        */    
+
+        monsterObject.addMonster(newName, select);
+        removeAllChildNodes(main);
+        monsterCards('monster'); // Ladda in monsterCards igen
+        e.preventDefault();
+
+      });
+
+      addMonsterForm.appendChild(inputAddButton); // xxx
+      addMonsterForm.appendChild(inputEditButton); // xxx  
+  
 }
+
+
+
+
+// Ladda in alla Select Boxes i Add monster
+LoadSelectBoxes();
+
+let btn = document.querySelector('#sub-btn');
+let editbtn = document.querySelector('#edit-btn');
+
+function monsterFeatures() {
+
+    removeAllChildNodes(monsterFeaturesDiv);
+
+    let monsterFeature;
+    let id;
+    let monsterFeatureType;
+    let checkbox = [];
+    let label = [];
+    let br = [];
+    let div = [];
+
+    for (let i=0; i<monsterObject.monsterFeatures.length; i++) {
+
+        // Ladda enbart in Features som inte är tomma/borttagna
+        // Element av typen undefined ignoreras       
+        if (typeof monsterObject.monsterFeatures[i][0] !== "undefined") {
+            
+            monsterFeature = monsterObject.monsterFeatures[i][1];
+            id = monsterObject.monsterFeatures[i][0];
+            monsterFeatureType = monsterObject.monsterFeatureType[id];
+
+            div[i] = document.createElement("div");
+            div[i].setAttribute("class", "mfeatures-subdiv");
+
+            checkbox[i] = document.createElement("input");
+            checkbox[i].setAttribute("type", "checkbox");
+            checkbox[i].setAttribute("class", "mfeatures-checkboxes");
+            checkbox[i].setAttribute("value", i);
+            checkbox[i].setAttribute("id", (monsterFeature + i));
+
+            label[i] = document.createElement("label");
+            label[i].innerHTML = `${monsterFeatureType}: <span style="color: ${monsterObject.monsterFeatures[i][2]}">${monsterFeature}</span>`;
+            label[i].setAttribute("class", "mlabel");
+            label[i].setAttribute("for", (monsterFeature + i));
+
+            div[i].appendChild(checkbox[i]);
+            div[i].appendChild(label[i]);
+
+            monsterFeaturesDiv.appendChild(div[i]);
+
+            (function(index) {           
+                checkbox[i].addEventListener("click", function() {
+                    // Remove feature if clicked/checked
+                    monsterObject.removeFeature(i);
+                    monsterFeatures(); // Run monsterFeatures function again to re-create the list
+                })
+            })(i)
+
+        }
+        
+    }
+
+}
+
+// Ladda in alla monsterFeatures i Edit-funktionen
+monsterFeatures();
+
+
 
 
 
@@ -114,12 +341,37 @@ function removeAllChildNodes(parent) {
 
 
 // Lägger man till ett till monster så läggs det till och uppdaterar main
+/* // Kod numera inflyttad i LoadSelectBoxes för dynamisk generering
 btn.addEventListener("click", function(e){
 
     monsterObject.addMonster();
     removeAllChildNodes(main);
     monsterCards('monster'); // Ladda in monsterCards igen
     e.preventDefault();
+  });
+  */
+
+  // Listener för att växla till Edit-monster sektionen
+editbtn.addEventListener("click", function(e) {
+
+    addMonster.style.display = "none";
+    editMonsters.style.display = "flex";
+    e.preventDefault();
+
+  });
+
+
+
+  
+
+    // Växla till Add-monster sektionen
+editbtn2.addEventListener("click", function(e) {
+
+    editMonsters.style.display = "none";  
+    addMonster.style.display = "flex";
+
+    e.preventDefault();
+
   });
 
   // Klickar man på Monster DB Titeln i headern så reloadas objectMonster.monster
@@ -204,6 +456,8 @@ function showMonsterColors() {
         valueArray[index][0] = value;
         valueArray[index][1] = amount;
         let li = document.createElement("li");
+        li.className="monsterColorLi";
+
         li.innerHTML = `${value}: ${amount}`;
         (function(index){
             li.addEventListener("click", function() {
@@ -241,6 +495,8 @@ function showMonsterTypes() {
         valueArray[index][0] = value;
         valueArray[index][1] = amount;
         let li = document.createElement("li");
+        li.className="monsterTypeLi";
+
         li.innerHTML = `${value}: ${amount}`;
 
         (function(index){
@@ -252,7 +508,6 @@ function showMonsterTypes() {
         mtypes.append(li);
 	});
 }
-
 
 showMonsterTypes();
 showMonsterColors();

--- a/style.css
+++ b/style.css
@@ -103,10 +103,24 @@ footer{
     
 }
 
+.edit-monsters {
+    /* I add-monster sektionen kör vi med FLEX och flex-direction: column */
+      display: none;
+      flex-direction: column;
+      grid-area: add-monster;
+      align-items: center;
+      border: 3px solid black;
+        /* vh används i höjdled och vw i sidled för att skala med mindre enheter */
+      padding: 1vh 2vw 1vh 2vw;
+      
+      background-color: #50577A;
+      color: white;   
+      display: none;
+      
+  }
 
 
-
-.monster-type{
+.monster-type {
     display: grid;
     grid-area: monster-type;
     border: 3px solid black;
@@ -115,7 +129,7 @@ footer{
     background-color: #50577A;
     color: white;
 }
-.monster-color{
+.monster-color {
     display: grid;
     grid-area: monster-color;
     border: 3px solid black;
@@ -125,12 +139,52 @@ footer{
     color: white;
 
 }
-#header-text{
+#header-text {
     margin: auto;
+    cursor: pointer;
+
 }
 
+/* Edit monsters, monster-features DIV container*/
+.monster-features {
 
+    padding-left: 0.5vw;  
+    padding-right: 0.5vw;     
+    padding-top: 1vh;
+    padding-bottom: 1vh;      
+    margin: 0px;  
+    margin-left: 1.4vw;
 
+}
+
+.mfeatures-subdiv {
+
+    min-width: min-content;
+
+}
+
+/* Edit monsters, monster-features checkboxes*/
+.mfeatures-checkboxes {
+    
+    margin-right: 3vh;
+    margin-left: 1vw;
+
+}
+
+.mlabel {
+
+    font-size: 20px;
+}
+
+.mlabel:hover {
+    text-decoration:line-through;
+    cursor:pointer; /* Mouse grab vid hovring */
+    background-color: #ffffff46;
+}
+.mlabel:active {
+    position:relative;
+    top:1px;
+}
 
  /* En massa view-width vw inlagt för att skala med mindre enheter */
  /* I höjdled kör vi view-height (vh) istället */
@@ -156,6 +210,9 @@ input[type=text] {
   .input-label {
     margin-left: 1.4vw;
     display: block;
+    margin-bottom: 0px;
+    padding-bottom: 0px;
+    height: 4vh;
   }
 
  /* En massa view-width vw inlagt för att skala med mindre enheter */
@@ -178,7 +235,7 @@ input[type=text] {
 
 
 
-#sub-btn {
+.sub-btn {
    
     /* I mobil-läge täcker knappen hela griddet, från vänster till höger */
     grid-column: 1 / 4;
@@ -209,11 +266,11 @@ input[type=text] {
         text-shadow: 0px 1px 0px #2f6627;
 
 }
-#sub-btn:hover {
+.sub-btn:hover {
     background-color:#474E68;
     color: #ffffff;
 }
-#sub-btn:active {
+.sub-btn:active {
     position:relative;
     top:1px;
 }
@@ -221,6 +278,11 @@ input[type=text] {
     margin: auto;
 }
 
+
+.monsterColorLi:hover,.monsterTypeLi:hover{
+    cursor: pointer;
+    background-color: #ffffff46;
+    }
 
 /* I mobil-läge har vi ett grid med 3 grid kolumner i formen */
 .add-monster-form {
@@ -273,7 +335,7 @@ input[type=text] {
     
     }
     /* Add monster knappen ska bara täcka 1 kolumn i Desktop-mode */
-    #sub-btn {   
+    .sub-btn {   
         grid-column: 1 / 2;
     }
 


### PR DESCRIPTION
- Olofs tidigare Hover JS och CSS tillagd. Blir nu grå bakgrund vid Hover över Monster Types och 
  Monster Colors. Mouse pointer också.

- Edit monster knapp med ny sektion för att ta bort och lägga till olika Monster Features.
  I dagsläget kan man dock bara ta bort existerande.

- CSS Hover funktion med genomstrykning och färgvärden som lagras i monsterObject.monsterFeatures[][2]
  T ex #ffff00 för gul. Vi kan alltså visa färger som färger om vi vill. Man skulle teoretiskt kunna
  bygga ut det med bilder(bildsökvägar) i monsterObject.monsterFeatures[][3]

- Tungt tillägg av function LoadSelectBoxes() funktion som genererar SELECT-boxes baserat på antalet
  olika typer av Features som finns i Monster Objektet. Gör att det automatiskt skapas nya SELECT-
  boxes för varje ny typ av FEATURE vi lägger till i framtiden, t ex Tentakler. Fyller vi i nya 
  FeatureTypes i monsterObject så dyker automatiskt SELECT-boxar med associerade
  <options> (Features) upp för det. Kommer även dyka upp automatiskt när vi senare gjort klar vår
  Lägg till Feature Type Funktion på sajten.

